### PR TITLE
Add WebP image conversion handling

### DIFF
--- a/Services/ImageService.cs
+++ b/Services/ImageService.cs
@@ -66,6 +66,24 @@ namespace DescriptionFixer.Services
                         html = HtmlParser.ReplaceImageSrc(html, src, newImage);
                     }
                 }
+                else if (src != null && src.ToLower().Contains(".webp"))
+                {
+                    // Convert WebP to PNG or JPG
+                    logger.Info($"Converting WebP image: {src}");
+                    MagickImage webp = await ImageUtils.GetAvifData(src);
+                    if (ImageUtils.IsImageTransparent(src, settings.TransparencyThreshold))
+                    {
+                        logger.Info($"WebP image is transparent, converting to PNG: {src}");
+                        string pngImage = ImageUtils.ConvertImage(webp, settings.Quality, "png", dataPath, game);
+                        html = HtmlParser.ReplaceImageSrc(html, src, pngImage);
+                        continue;
+                    }
+                    else
+                    {
+                        // No need to convert if not transparent
+                        logger.Info($"WebP image is not transparent, keeping as WebP: {src}");
+                    }
+                }
             }
             return html;
         }


### PR DESCRIPTION
Add WebP image conversion handling

Implemented functionality to convert WebP images. The code now logs the conversion process, checks for transparency, and converts to PNG if the image is transparent. If not transparent, the WebP format is retained.