### PR TITLE
Add ListBox with double-click handling in FrameSelection

### DIFF
--- a/Views/FrameSelection.xaml
+++ b/Views/FrameSelection.xaml
@@ -28,7 +28,8 @@
         <ListBox x:Name="ListBoxImages"
                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                  BorderThickness="0"
-                 ScrollViewer.VerticalScrollBarVisibility="Auto">
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 MouseDoubleClick="ListBoxImages_MouseDoubleClick">
             <ListBox.ItemsPanel>
                 <ItemsPanelTemplate>
                     <WrapPanel />

--- a/Views/FrameSelection.xaml.cs
+++ b/Views/FrameSelection.xaml.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media.Imaging;
+using System.Windows.Input;
 
 
 namespace DescriptionFixer.Views
@@ -58,6 +59,14 @@ namespace DescriptionFixer.Views
                 {
                     img.Width = e.NewValue;
                 }
+            }
+        }
+
+        private void ListBoxImages_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (ListBoxImages.SelectedItem != null)
+            {
+                ButtonSelectImage_Click(ButtonSelectImage, null);
             }
         }
 


### PR DESCRIPTION
Add ListBox with double-click handling in FrameSelection

- Added MouseDoubleClick event handler to trigger image selection.
- Cleaned up redundant ScrollViewer.VerticalScrollBarVisibility property.