### PR TITLE
Set-Max-Width

### DIFF
--- a/DescriptionFixer.cs
+++ b/DescriptionFixer.cs
@@ -93,7 +93,7 @@ namespace DescriptionFixer
                     changesVideo += cvideo;
 
                     // Set Image Max-Width
-                    ImageUtils.SetMaxWidth(fixedDescription);                    
+                    fixedDescription = ImageUtils.SetMaxWidth(fixedDescription);                    
 
                     // Emoji processing
                     int cEmoji = 0;

--- a/DescriptionFixer.cs
+++ b/DescriptionFixer.cs
@@ -9,6 +9,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Threading.Tasks;
 using HtmlAgilityPack;
+using DescriptionFixer.Utilities;
 
 namespace DescriptionFixer
 {
@@ -90,6 +91,9 @@ namespace DescriptionFixer
                     int cvideo = 0;
                     (fixedDescription, cvideo) = videoSvc.ProcessVideos(game, fixedDescription);
                     changesVideo += cvideo;
+
+                    // Set Image Max-Width
+                    ImageUtils.SetMaxWidth(fixedDescription);                    
 
                     // Emoji processing
                     int cEmoji = 0;

--- a/Manifests/DescriptionFixerManifest.yaml
+++ b/Manifests/DescriptionFixerManifest.yaml
@@ -54,3 +54,10 @@ Packages:
       - 4 - Reduce excessive spacing before lists.
       - New ~~ Ctrl+MouseWheel support for zooming in and out of image selection window.
       - New ~~ Double click image in image selection window to select it.
+  - Version: 1.6
+    RequiredApiVersion: 6.12.0
+    ReleaseDate: 2025-09-09
+    PackageUrl: https://github.com/azuravian/playnite-DescriptionFixer/releases/download/v1.6/DescriptionFixer_b86cf867-0519-49ef-b7b7-386b6a1e2830_1_6.pext
+    Changelog:
+      - Incorporated PR10 from @Jeshibu
+      - Fixed issue No. 9 where some images have attributes causing them to extend outside of the borders of the description field.

--- a/Utilities/ImageUtils.cs
+++ b/Utilities/ImageUtils.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace DescriptionFixer.Utilities
 {
@@ -169,5 +168,22 @@ namespace DescriptionFixer.Utilities
             return extractedFrames;
         }
 
+        public static string SetMaxWidth(string html)
+        {
+            var doc = new HtmlAgilityPack.HtmlDocument();
+            doc.LoadHtml(html);
+            var imgNodes = doc.DocumentNode.SelectNodes("//img");
+            if (imgNodes != null)
+            {
+                foreach (var img in imgNodes)
+                {
+                    var style = img.GetAttributeValue("style", "");
+                    if (!style.Contains("max-width"))
+                        img.SetAttributeValue("style", "max-width: 100%; height: auto;");
+                }
+                return doc.DocumentNode.OuterHtml;
+            }
+            return html;
+        }
     }
 }

--- a/extension.yaml
+++ b/extension.yaml
@@ -1,7 +1,7 @@
 ﻿Id: DescriptionFixer_b86cf867-0519-49ef-b7b7-386b6a1e2830
 Name: Description Fixer
 Author: Azuravian
-Version: 1.5
+Version: 1.6
 Module: DescriptionFixer.dll
 Type: GenericPlugin
 Icon: icon.png


### PR DESCRIPTION
#### PR Classification
New feature to enhance image handling in HTML descriptions.

#### PR Summary
This pull request introduces a utility method to ensure images in HTML descriptions are properly sized and updates the plugin's versioning and metadata. 
- `ImageUtils.cs`: Added `SetMaxWidth` method to adjust image styles in HTML.
- `DescriptionFixer.cs`: Updated to call `SetMaxWidth` after video processing.
- `DescriptionFixerManifest.yaml`: Updated version to 1.6 and added a changelog.
- `extension.yaml`: Updated version number to 1.6 for the Description Fixer plugin.
